### PR TITLE
Strip leading space when wrapped lines are joined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ convert = function(source) {
   for (i = 0, linesLength = lines.length; i < linesLength; i++) {
     line = lines[i];
     if (line.charAt(0) === " ") {
-      currentObj[currentKey] += line;
+      currentObj[currentKey] += line.substr(1);
 
     } else {
       splitAt = line.indexOf(":");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ical2json",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A simple node package to convert ical to JSON",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var ical2json = require("./index"),
-    eventString = "BEGIN:VEVENT\nDTSTART;VALUE=DATE:20130101\nDTEND;VALUE=DATE:20130102\nDTSTAMP:20111213T124028Z\nUID:9d6fa48343f70300fe3109efe@calendarlabs.com\nCREATED:20111213T123901Z\nDESCRIPTION:Visit http://calendarlabs.com/holidays/us/new-years-day.php to know more about New Year's Day. Like us on Facebook: http://fb.com/calendarlabs to get updates.\nLAST-MODIFIED:20111213T123901Z\nLOCATION:\nSEQUENCE:0\nSTATUS:CONFIRMED\nSUMMARY:New Year's Day\nTRANSP:TRANSPARENT\nEND:VEVENT";
+    eventString = "BEGIN:VEVENT\nDTSTART;VALUE=DATE:20130101\nDTEND;VALUE=DATE:20130102\nDTSTAMP:20111213T124028Z\nUID:9d6fa48343f70300fe3109efe@calendarlabs.com\nCREATED:20111213T123901Z\nDESCRIPTION:Visit http://calendarlabs.com/holidays/us/new-years-day.php to kn\n ow more about New Year's Day. Like us on Facebook: http://fb.com/calendarlabs to get updates.\nLAST-MODIFIED:20111213T123901Z\nLOCATION:\nSEQUENCE:0\nSTATUS:CONFIRMED\nSUMMARY:New Year's Day\nTRANSP:TRANSPARENT\nEND:VEVENT";
 
 exports.convert = {
   setUp: function (callback) {


### PR DESCRIPTION
From RFC 5545:

"a long line can be split between any two characters by inserting a CRLF
immediately followed by a single linear white-space character (i.e.,
SPACE or HTAB).  Any sequence of CRLF followed immediately by a
single linear white-space character is ignored (i.e., removed) when
processing the content type."

http://tools.ietf.org/html/rfc5545#section-3.1
