### PR TITLE
Fixed issue where multiple child nodes could get incorrectly nested

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ convert = function(source) {
       splitAt;
 
   currentObj = output;
+  parents = [];
 
   for (i = 0, linesLength = lines.length; i < linesLength; i++) {
     line = lines[i];
@@ -38,6 +39,7 @@ convert = function(source) {
 
       switch (currentKey) {
         case "BEGIN":
+          parents.push(parentObj);
           parentObj = currentObj;
           if (parentObj[currentValue] == null) {
             parentObj[currentValue] = [];
@@ -47,6 +49,7 @@ convert = function(source) {
           break;
         case "END":
           currentObj = parentObj;
+          parentObj = parents.shift();
           break;
         default:
           currentObj[currentKey] = currentValue;

--- a/test.js
+++ b/test.js
@@ -50,3 +50,16 @@ exports["convert old newline"] = {
     test.done();
   }
 };
+
+exports["convert multi-child"] = {
+  "make sure multiple child nodes are handled correctly": function (test) {
+    eventString = "BEGIN:VEVENT\nINDEX:1\nBEGIN:VALARM\nTRIGGER:-P1DT0H0M0S\nEND:VALARM\nBEGIN:VALARM\nTRIGGER:-P0DT1H0M0S\nEND:VALARM\nEND:VEVENT\nBEGIN:VEVENT\nINDEX:2\nBEGIN:VALARM\nTRIGGER:-P1DT0H0M0S\nEND:VALARM\nBEGIN:VALARM\nTRIGGER:-P0DT1H0M0S\nEND:VALARM\nEND:VEVENT"
+    eventObjs = ical2json.convert(eventString);
+
+    test.equal(eventObjs.VEVENT.length, 2);
+    test.equal(eventObjs.VEVENT[0].VALARM.length, 2);
+    test.equal(eventObjs.VEVENT[1].VALARM.length, 2);
+
+    test.done();
+  }
+};


### PR DESCRIPTION
Previously, an iCalendar file like the following (indentation added for clarity) would result in VEVENT nodes being nested:

```
BEGIN:VEVENT
    INDEX:1
    BEGIN:VALARM
        TRIGGER:-P1DT0H0M0S
    END:VALARM
    BEGIN:VALARM
        TRIGGER:-P0DT1H0M0S
    END:VALARM
END:VEVENT
BEGIN:VEVENT
    INDEX:2
    BEGIN:VALARM
        TRIGGER:-P1DT0H0M0S
    END:VALARM
    BEGIN:VALARM
        TRIGGER:-P0DT1H0M0S
    END:VALARM
END:VEVENT
```

This was because of an incorrect assumption in the code that the parent object for a node should always be the most recently added object. This change tracks parent nodes explicitly.