### PR TITLE
handle multiple child nodes without BEGIN-END

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,15 @@ convert = function(source) {
           parentObj = parents.shift();
           break;
         default:
-          currentObj[currentKey] = currentValue;
+          if(currentObj[currentKey]) {
+            if(currentObj[currentKey].constructor === Array) {
+              currentObj[currentKey].push(currentValue);
+            } else {
+              currentObj[currentKey] = [currentObj[currentKey], currentValue];
+            }
+          } else {
+            currentObj[currentKey] = currentValue;
+          }
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -54,11 +54,10 @@ convert = function(source) {
           break;
         default:
           if(currentObj[currentKey]) {
-            if(currentObj[currentKey].constructor === Array) {
-              currentObj[currentKey].push(currentValue);
-            } else {
-              currentObj[currentKey] = [currentObj[currentKey], currentValue];
+            if(!Array.isArray(currentObj[currentKey])) {
+              currentObj[currentKey] = [currentObj[currentKey]];
             }
+            currentObj[currentKey].push(currentValue);
           } else {
             currentObj[currentKey] = currentValue;
           }

--- a/test.js
+++ b/test.js
@@ -63,3 +63,13 @@ exports["convert multi-child"] = {
     test.done();
   }
 };
+
+exports["convert multi-child w/o BEGIN-END"] =  {
+  "make sure multiple child nodes are handled properly": function (test) {
+    eventString = "BEGIN:VEVENT\nDTSTART;VALUE=DATE:20130101\nDTEND;VALUE=DATE:20130102\nDTSTAMP:20111213T124028Z\nUID:9d6fa48343f70300fe3109efe@calendarlabs.com\nCREATED:20111213T123901Z\nDESCRIPTION:Visit http://calendarlabs.com/holidays/us/new-years-day.php to kn\n ow more about New Year's Day. Like us on Facebook: http://fb.com/calendarlabs to get updates.\nLAST-MODIFIED:20111213T123901Z\nLOCATION:\nSEQUENCE:0\nSTATUS:CONFIRMED\nSUMMARY:New Year's Day\nEXDATE:20111215T093000\nEXDATE:20111216T093000\nTRANSP:TRANSPARENT\nEND:VEVENT";
+    eventObjs = ical2json.convert(eventString);
+
+    test.deepEqual(eventObjs.VEVENT[0].EXDATE, [ "20111215T093000", "20111216T093000" ]);
+    test.done();
+  }
+};


### PR DESCRIPTION
Multiple child nodes which doesn't have BEGIN-END node, just captures the last value the node. 
For example, the following event is extracted from Google Calendar.
```
BEGIN:VEVENT
DTSTART;TZID=America/Toronto:20160628T083000
DTEND;TZID=America/Toronto:20160628T093000
RRULE:FREQ=WEEKLY;UNTIL=20160830T123000Z;BYDAY=MO,TU
EXDATE;TZID=America/Toronto:20160711T083000
EXDATE;TZID=America/Toronto:20160705T083000
DTSTAMP:20160628T202103Z
CREATED:20160628T201224Z
LAST-MODIFIED:20160628T201554Z
STATUS:CONFIRMED
SUMMARY:Sample Event Test
END:VEVENT
```
Here, the `EXDATE` has multiple occurrence so it should have an array of values instead of just last value.