### PR TITLE
Fix notation for RDATE

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function revert(object) {
     if (Array.isArray(value)) {
       if (key === "RDATE") {
         value.forEach(function(item) {
-          lines.push(key + ":" +item );
+          lines.push(key + ":" + item);
         });
       } else {
         value.forEach(function(item) {

--- a/index.js
+++ b/index.js
@@ -82,11 +82,15 @@ function revert(object) {
   for (var key in object) {
     var value = object[key];
     if (Array.isArray(value)) {
-      value.forEach(function (item) {
-        lines.push("BEGIN:" + key);
-        lines.push(revert(item));
-        lines.push("END:" + key);
-      });
+      if (key === 'RDATE') {
+        value.forEach(item => lines.push(`${key}:${item}`));
+      } else {
+        value.forEach(item => {
+          lines.push(`BEGIN:${key}`);
+          lines.push(revert(item));
+          lines.push(`END:${key}`);
+        });
+      }
     } else {
       var fullLine = key + ":" + value;
       do {

--- a/index.js
+++ b/index.js
@@ -82,13 +82,15 @@ function revert(object) {
   for (var key in object) {
     var value = object[key];
     if (Array.isArray(value)) {
-      if (key === 'RDATE') {
-        value.forEach(item => lines.push(`${key}:${item}`));
+      if (key === "RDATE") {
+        value.forEach(function(item) {
+          lines.push(key + ":" +item );
+        });
       } else {
-        value.forEach(item => {
-          lines.push(`BEGIN:${key}`);
+        value.forEach(function(item) {
+          lines.push("BEGIN:" + key);
           lines.push(revert(item));
-          lines.push(`END:${key}`);
+          lines.push("END:" + key);
         });
       }
     } else {

--- a/test/ical2json.js
+++ b/test/ical2json.js
@@ -20,7 +20,7 @@ test("converting and reverting result in same content", t => {
   const normalize = text => text.replace(/\n\s?/g, "");
 
   const sampleContent =
-    "BEGIN:VEVENT\nDTSTART;VALUE=DATE:20130101\nDTEND;VALUE=DATE:20130102\nDTSTAMP:20111213T124028Z\nUID:9d6fa48343f70300fe3109efe@calendarlabs.com\nCREATED:20111213T123901Z\nDESCRIPTION:Visit http://calendarlabs.com/holidays/us/new-years-day.php to kn\n ow more about New Year's Day. Like us on Facebook: http://fb.com/calendarlabs to get updates.\nLAST-MODIFIED:20111213T123901Z\nLOCATION:\nSEQUENCE:0\nSTATUS:CONFIRMED\nSUMMARY:New Year's Day\nTRANSP:TRANSPARENT\nEND:VEVENT";
+    "BEGIN:VEVENT\nDTSTART;VALUE=DATE:20130101\nDTEND;VALUE=DATE:20130102\nDTSTAMP:20111213T124028Z\nRDATE:20111213T124028Z\nRDATE:20111213T124028Z\nUID:9d6fa48343f70300fe3109efe@calendarlabs.com\nCREATED:20111213T123901Z\nDESCRIPTION:Visit http://calendarlabs.com/holidays/us/new-years-day.php to kn\n ow more about New Year's Day. Like us on Facebook: http://fb.com/calendarlabs to get updates.\nLAST-MODIFIED:20111213T123901Z\nLOCATION:\nSEQUENCE:0\nSTATUS:CONFIRMED\nSUMMARY:New Year's Day\nTRANSP:TRANSPARENT\nEND:VEVENT";
   const output = revert(convert(sampleContent));
   t.is(normalize(output), normalize(sampleContent));
 });


### PR DESCRIPTION
The notation for RDATE when converting back from json is broken and causes issues while importing the resulting ics.

See [rfc5545 section 3.8.5.2](https://tools.ietf.org/html/rfc5545#section-3.8.5.2) for an example on how RDATE is used.