### PR TITLE
Add types on npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ical2json",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ical2json",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^6.2.1"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.0",
   "description": "A simple node package to convert ical to JSON",
   "main": "build/ical2json.js",
+  "types": "build/ical2json.d.ts",
   "files": [
     "bin/icaljson",
     "build/cli.js",


### PR DESCRIPTION
Hello, 

Types still seem missing on npm package, I think we need to add "types" property in `package.js` but I'm not sure 😊

I also updated the package-lock package version.